### PR TITLE
Added option to disable GTM tags

### DIFF
--- a/dataLayer.php
+++ b/dataLayer.php
@@ -3,7 +3,7 @@
  * Plugin Name: Wp DataLayer
  * Plugin URI: http://bonnierpublications.com
  * Description: WordPress Datalayer implementation
- * Version: 0.1.4
+ * Version: 0.1.5
  * Author: Michael Sørensen
  * Author URI: http://bonnierpublications.com
  */

--- a/src/Controllers/SettingsController.php
+++ b/src/Controllers/SettingsController.php
@@ -60,6 +60,10 @@ class SettingsController
                     ],
                 ],
             ],
+            'disabled' => [
+                'type' => 'checkbox',
+                'name' => 'Disable GTM tags on site'
+            ]
         ];
     }
 


### PR DESCRIPTION
For sites like FZ, we have to disable the GTM code injection, as it uses the one from the WhiteAlbum shell.